### PR TITLE
Add missing build dependencies

### DIFF
--- a/doc/build-unix.md
+++ b/doc/build-unix.md
@@ -59,7 +59,7 @@ Dependency Build Instructions: Ubuntu & Debian
 ----------------------------------------------
 Build requirements:
 
-	sudo apt-get install build-essential libtool autotools-dev autoconf pkg-config libssl-dev
+	sudo apt-get install build-essential libtool autotools-dev autoconf pkg-config libssl-dev automake libevent-dev
 
 For Ubuntu 12.04 and later or Debian 7 and later libboost-all-dev has to be installed:
 


### PR DESCRIPTION
The packages `automake libevent-dev` where missing when building in a clean Ubuntu 14.04 docker container